### PR TITLE
Network settings + some cleanup

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -60,6 +60,7 @@ export const store = configureStore({
 });
 
 export type AppDispatch = typeof store.dispatch;
+export type RootState = ReturnType<typeof store.getState>;
 
 export const App = () => (
   <Provider store={store}>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,18 +8,19 @@ import {
 import { combineReducers, Action } from "redux";
 import { Provider } from "react-redux";
 import { createGlobalStyle } from "styled-components";
+import BigNumber from "bignumber.js";
 
 import { Landing } from "pages/Landing";
 import { Dashboard } from "pages/Dashboard";
+import { Network } from "components/Network";
 import { PrivateRoute } from "components/PrivateRoute";
 
 import { reducer as account } from "ducks/account";
-import { reducer as sendTx } from "ducks/sendTransaction";
-import { reducer as txHistory } from "ducks/txHistory";
 import { reducer as keyStore } from "ducks/keyStore";
+import { reducer as sendTx } from "ducks/sendTransaction";
+import { reducer as settings } from "ducks/settings";
+import { reducer as txHistory } from "ducks/txHistory";
 import { reducer as walletTrezor } from "ducks/wallet/trezor";
-
-import BigNumber from "bignumber.js";
 
 const GlobalStyle = createGlobalStyle`
   body {
@@ -39,12 +40,13 @@ const loggerMiddleware = (store: any) => (next: any) => (
 const isSerializable = (value: any) =>
   BigNumber.isBigNumber(value) || isPlain(value);
 
-const store = configureStore({
+export const store = configureStore({
   reducer: combineReducers({
     account,
-    sendTx,
-    txHistory,
     keyStore,
+    sendTx,
+    settings,
+    txHistory,
     walletTrezor,
   }),
   middleware: [
@@ -62,7 +64,7 @@ export type AppDispatch = typeof store.dispatch;
 export const App = () => (
   <Provider store={store}>
     <Router>
-      <div>
+      <Network>
         <GlobalStyle />
 
         <Switch>
@@ -76,7 +78,7 @@ export const App = () => (
 
           {/* TODO: add 404 page */}
         </Switch>
-      </div>
+      </Network>
     </Router>
   </Provider>
 );

--- a/src/components/Network.tsx
+++ b/src/components/Network.tsx
@@ -1,0 +1,51 @@
+import React, { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+import { useDispatch } from "react-redux";
+import styled from "styled-components";
+import { update } from "ducks/settings";
+import { useRedux } from "hooks/useRedux";
+
+const BannerEl = styled.div`
+  width: 100%;
+  padding: 10px 0;
+  text-align: center;
+  background-color: #c00;
+  color: #fff;
+`;
+
+interface NetworkProps {
+  children: React.ReactNode;
+}
+
+export const Network = ({ children }: NetworkProps) => {
+  const dispatch = useDispatch();
+  const { settings } = useRedux(["settings"]);
+  const queryParams = new URLSearchParams(useLocation().search);
+  const testnetParam = queryParams.get("testnet");
+
+  const isDevelopment = process.env.NODE_ENV === "development";
+  const isTestnet = testnetParam === "true";
+  const showNetworkMessage =
+    (isDevelopment && !settings.isTestnet) ||
+    (!isDevelopment && settings.isTestnet);
+
+  const handleTestnetParamChange = () => {
+    if (testnetParam) {
+      // route and store will reset when page reloads on query change
+      dispatch(update({ isTestnet }));
+    }
+  };
+
+  useEffect(handleTestnetParamChange, [isTestnet]);
+
+  return (
+    <>
+      {showNetworkMessage && (
+        <BannerEl>{`You are using ${isTestnet ? "TEST" : "PUBLIC"} network in ${
+          isDevelopment ? "DEVELOPMENT" : "PRODUCTION"
+        }`}</BannerEl>
+      )}
+      {children}
+    </>
+  );
+};

--- a/src/components/SendTransaction/ConfirmTransaction.tsx
+++ b/src/components/SendTransaction/ConfirmTransaction.tsx
@@ -5,7 +5,7 @@ import { useDispatch } from "react-redux";
 import { useRedux } from "hooks/useRedux";
 import { loadPrivateKey } from "helpers/keyManager";
 import { sendTxAction } from "ducks/sendTransaction";
-import { ActionStatus } from "ducks/account";
+import { ActionStatus } from "constants/types.d";
 import { FormData } from "./SendTransactionFlow";
 
 const El = styled.div``;

--- a/src/components/SendTransaction/CreateTransaction.tsx
+++ b/src/components/SendTransaction/CreateTransaction.tsx
@@ -1,10 +1,9 @@
 import React, { useState } from "react";
-import StellarSdk, { MemoType , FederationServer } from "stellar-sdk";
+import StellarSdk, { MemoType, FederationServer } from "stellar-sdk";
 import styled from "styled-components";
 import BigNumber from "bignumber.js";
-import { ActionStatus } from "ducks/account";
+import { ActionStatus } from "constants/types.d";
 import { FormData } from "./SendTransactionFlow";
-
 
 const El = styled.div`
   margin-bottom: 20px;

--- a/src/components/SendTransaction/SuccessfulTransaction.tsx
+++ b/src/components/SendTransaction/SuccessfulTransaction.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import styled from "styled-components";
 import { useRedux } from "hooks/useRedux";
-import { getNetworkConfig } from "constants/settings";
+import { getNetworkConfig } from "helpers/getNetworkConfig";
 
 const El = styled.div``;
 
@@ -18,14 +18,17 @@ const TempAnchorEl = styled.a`
 
 export const SuccessfulTransaction = (props: { onRestartFlow: () => void }) => {
   const { onRestartFlow } = props;
-  const { sendTx } = useRedux("sendTx");
+  const { sendTx, settings } = useRedux("sendTx", "settings");
+
   return (
     <El>
       <h1>Success</h1>
       <El>{sendTx.data.result_xdr}</El>
       <El>
         <TempAnchorEl
-          href={`${getNetworkConfig().stellarExpertTxUrl}${sendTx.data.id}`}
+          href={`${getNetworkConfig(settings.isTestnet).stellarExpertTxUrl}${
+            sendTx.data.id
+          }`}
           target="_blank"
         >
           See details on StellarExpert

--- a/src/components/SendTransaction/SuccessfulTransaction.tsx
+++ b/src/components/SendTransaction/SuccessfulTransaction.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import styled from "styled-components";
 import { useRedux } from "hooks/useRedux";
+import { getNetworkConfig } from "constants/settings";
 
 const El = styled.div``;
 
@@ -23,9 +24,8 @@ export const SuccessfulTransaction = (props: { onRestartFlow: () => void }) => {
       <h1>Success</h1>
       <El>{sendTx.data.result_xdr}</El>
       <El>
-        {/* } TODO - network config */}
         <TempAnchorEl
-          href={`https://stellar.expert/explorer/testnet/tx/${sendTx.data.id}`}
+          href={`${getNetworkConfig().stellarExpertTxUrl}${sendTx.data.id}`}
           target="_blank"
         >
           See details on StellarExpert

--- a/src/components/SigninSecretKeyForm.tsx
+++ b/src/components/SigninSecretKeyForm.tsx
@@ -4,9 +4,10 @@ import { useDispatch } from "react-redux";
 import styled from "styled-components";
 import { Keypair } from "stellar-sdk";
 
-import { fetchAccountAction, ActionStatus } from "ducks/account";
+import { fetchAccountAction } from "ducks/account";
 import { storePrivateKeyAction } from "ducks/keyStore";
 import { useRedux } from "hooks/useRedux";
+import { ActionStatus } from "constants/types.d";
 
 const WarningEl = styled.div`
   background-color: #f3e5e5;

--- a/src/components/SigninTrezorForm.tsx
+++ b/src/components/SigninTrezorForm.tsx
@@ -6,7 +6,7 @@ import { useDispatch } from "react-redux";
 // @ts-ignore
 import TrezorConnect from "trezor-connect";
 
-import { fetchAccountAction } from "ducks/account";
+import { fetchAccountAction, reset as resetAccount } from "ducks/account";
 import {
   fetchTrezorStellarAddressAction,
   reset as resetTrezor,
@@ -111,13 +111,13 @@ export const SigninTrezorForm = ({ onClose }: SigninTrezorFormProps) => {
     }
   };
 
-  const resetOnMount = () => {
+  const resetOnUnmount = () => {
     dispatch(resetTrezor());
+    dispatch(resetAccount());
   };
 
-  // TODO: once network config is in place, make sure everything is reset
-  // properly (errors cleared, etc)
-  useEffect(resetOnMount, []);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => resetOnUnmount, []);
   useEffect(handleTrezorStatusChange, [trezorStatus, trezorErrorMessage]);
   useEffect(handleAccountStatusChange, [accountStatus, accountErrorMessage]);
 

--- a/src/components/SigninTrezorForm.tsx
+++ b/src/components/SigninTrezorForm.tsx
@@ -6,16 +6,13 @@ import { useDispatch } from "react-redux";
 // @ts-ignore
 import TrezorConnect from "trezor-connect";
 
-import {
-  fetchAccountAction,
-  ActionStatus as AccountActionStatus,
-} from "ducks/account";
+import { fetchAccountAction } from "ducks/account";
 import {
   fetchTrezorStellarAddressAction,
-  ActionStatus as TrezorActionStatus,
-  actions as trezorActions,
+  reset as resetTrezor,
 } from "ducks/wallet/trezor";
 import { useRedux } from "hooks/useRedux";
+import { ActionStatus } from "constants/types.d";
 
 const InfoEl = styled.div`
   background-color: #dbdbdb;
@@ -86,7 +83,7 @@ export const SigninTrezorForm = ({ onClose }: SigninTrezorFormProps) => {
       return;
     }
 
-    if (trezorStatus === TrezorActionStatus.SUCCESS) {
+    if (trezorStatus === ActionStatus.SUCCESS) {
       if (trezorData) {
         try {
           dispatch(fetchAccountAction(trezorData));
@@ -105,7 +102,7 @@ export const SigninTrezorForm = ({ onClose }: SigninTrezorFormProps) => {
       return;
     }
 
-    if (accountStatus === AccountActionStatus.SUCCESS) {
+    if (accountStatus === ActionStatus.SUCCESS) {
       if (isAuthenticated) {
         history.push("/dashboard");
       } else {
@@ -115,7 +112,7 @@ export const SigninTrezorForm = ({ onClose }: SigninTrezorFormProps) => {
   };
 
   const resetOnMount = () => {
-    dispatch(trezorActions.reset());
+    dispatch(resetTrezor());
   };
 
   // TODO: once network config is in place, make sure everything is reset
@@ -135,7 +132,7 @@ export const SigninTrezorForm = ({ onClose }: SigninTrezorFormProps) => {
         </>
       )}
 
-      {trezorStatus === TrezorActionStatus.PENDING && (
+      {trezorStatus === ActionStatus.PENDING && (
         <InfoEl>Please follow the instructions in the Trezor popup.</InfoEl>
       )}
 

--- a/src/constants/settings.ts
+++ b/src/constants/settings.ts
@@ -35,5 +35,3 @@ export const getNetworkConfig = () => {
   const network = isTestnet() ? NetworkType.TESTNET : NetworkType.PUBLIC;
   return networkConfig[network];
 };
-
-export const getServer = () => new StellarSdk.Server(getNetworkConfig().url);

--- a/src/constants/settings.ts
+++ b/src/constants/settings.ts
@@ -1,6 +1,4 @@
 import StellarSdk from "stellar-sdk";
-import { store } from "App";
-import { NetworkType } from "constants/types.d";
 
 interface NetworkItemConfig {
   url: string;
@@ -24,14 +22,4 @@ export const networkConfig: NetworkConfig = {
     network: StellarSdk.Networks.PUBLIC,
     stellarExpertTxUrl: "https://stellar.expert/explorer/public/tx/",
   },
-};
-
-const isTestnet = () => {
-  const { settings } = store.getState();
-  return settings.isTestnet;
-};
-
-export const getNetworkConfig = () => {
-  const network = isTestnet() ? NetworkType.TESTNET : NetworkType.PUBLIC;
-  return networkConfig[network];
 };

--- a/src/constants/settings.ts
+++ b/src/constants/settings.ts
@@ -1,0 +1,39 @@
+import StellarSdk from "stellar-sdk";
+import { store } from "App";
+import { NetworkType } from "constants/types.d";
+
+interface NetworkItemConfig {
+  url: string;
+  network: string;
+  stellarExpertTxUrl: string;
+}
+
+interface NetworkConfig {
+  testnet: NetworkItemConfig;
+  public: NetworkItemConfig;
+}
+
+export const networkConfig: NetworkConfig = {
+  testnet: {
+    url: "https://horizon-testnet.stellar.org",
+    network: StellarSdk.Networks.TESTNET,
+    stellarExpertTxUrl: "https://stellar.expert/explorer/testnet/tx/",
+  },
+  public: {
+    url: "https://horizon.stellar.org",
+    network: StellarSdk.Networks.PUBLIC,
+    stellarExpertTxUrl: "https://stellar.expert/explorer/public/tx/",
+  },
+};
+
+const isTestnet = () => {
+  const { settings } = store.getState();
+  return settings.isTestnet;
+};
+
+export const getNetworkConfig = () => {
+  const network = isTestnet() ? NetworkType.TESTNET : NetworkType.PUBLIC;
+  return networkConfig[network];
+};
+
+export const getServer = () => new StellarSdk.Server(getNetworkConfig().url);

--- a/src/constants/types.d.ts
+++ b/src/constants/types.d.ts
@@ -1,0 +1,14 @@
+export enum NetworkType {
+  TESTNET = "testnet",
+  PUBLIC = "public",
+}
+
+export enum ActionStatus {
+  PENDING = "PENDING",
+  SUCCESS = "SUCCESS",
+  ERROR = "ERROR",
+}
+
+export interface RejectMessage {
+  errorMessage: string;
+}

--- a/src/ducks/account.ts
+++ b/src/ducks/account.ts
@@ -1,6 +1,7 @@
 import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
 import { DataProvider, Types } from "@stellar/wallet-sdk";
-import StellarSdk from "stellar-sdk";
+import { getNetworkConfig } from "constants/settings";
+import { ActionStatus, RejectMessage } from "constants/types.d";
 
 export const fetchAccountAction = createAsyncThunk<
   // Return type of the payload creator
@@ -11,10 +12,9 @@ export const fetchAccountAction = createAsyncThunk<
   { rejectValue: RejectMessage }
 >("account/fetchAccountAction", async (publicKey, { rejectWithValue }) => {
   const dataProvider = new DataProvider({
-    // TODO: move to config (support mainnet and testnet)
-    serverUrl: "https://horizon-testnet.stellar.org",
+    serverUrl: getNetworkConfig().url,
     accountOrKey: publicKey,
-    networkPassphrase: StellarSdk.Networks.TESTNET,
+    networkPassphrase: getNetworkConfig().network,
   });
 
   let stellarAccount: Types.AccountDetails | null = null;
@@ -29,16 +29,6 @@ export const fetchAccountAction = createAsyncThunk<
 
   return stellarAccount;
 });
-
-interface RejectMessage {
-  errorMessage: string;
-}
-
-export enum ActionStatus {
-  PENDING = "PENDING",
-  SUCCESS = "SUCCESS",
-  ERROR = "ERROR",
-}
 
 interface InitialState {
   data: Types.AccountDetails | null;

--- a/src/ducks/account.ts
+++ b/src/ducks/account.ts
@@ -47,7 +47,9 @@ const initialState: InitialState = {
 const accountSlice = createSlice({
   name: "account",
   initialState,
-  reducers: {},
+  reducers: {
+    reset: () => initialState,
+  },
   extraReducers: (builder) => {
     builder.addCase(fetchAccountAction.pending, (state) => ({
       ...state,
@@ -74,3 +76,4 @@ const accountSlice = createSlice({
 });
 
 export const { reducer } = accountSlice;
+export const { reset } = accountSlice.actions;

--- a/src/ducks/keyStore.ts
+++ b/src/ducks/keyStore.ts
@@ -1,5 +1,6 @@
 import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
 import { storePrivateKey, CreateKeyManagerResponse } from "helpers/keyManager";
+import { RejectMessage } from "constants/types.d";
 
 export const storePrivateKeyAction = createAsyncThunk<
   CreateKeyManagerResponse,
@@ -16,10 +17,6 @@ export const storePrivateKeyAction = createAsyncThunk<
   }
   return result;
 });
-
-interface RejectMessage {
-  errorMessage: string;
-}
 
 interface InitialState {
   id: string;

--- a/src/ducks/sendTransaction.ts
+++ b/src/ducks/sendTransaction.ts
@@ -2,7 +2,7 @@ import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
 import { MemoType, MemoValue, Horizon } from "stellar-sdk";
 import BigNumber from "bignumber.js";
 import { submitPaymentTransaction } from "helpers/submitPaymentTransaction";
-import { ActionStatus } from "./account";
+import { ActionStatus } from "constants/types.d";
 
 export interface PaymentTransactionParams {
   secret: string;

--- a/src/ducks/settings.ts
+++ b/src/ducks/settings.ts
@@ -1,4 +1,5 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import { RootState } from "App";
 
 interface InitialState {
   isTestnet: boolean;
@@ -22,6 +23,8 @@ const settingsSlice = createSlice({
     }),
   },
 });
+
+export const isTestnetSelector = (state: RootState) => state.settings.isTestnet;
 
 export const { reducer } = settingsSlice;
 export const { update } = settingsSlice.actions;

--- a/src/ducks/settings.ts
+++ b/src/ducks/settings.ts
@@ -1,0 +1,27 @@
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+
+interface InitialState {
+  isTestnet: boolean;
+}
+
+interface Setting {
+  [key: string]: any;
+}
+
+const initialState: InitialState = {
+  isTestnet: process.env.NODE_ENV === "development",
+};
+
+const settingsSlice = createSlice({
+  name: "settings",
+  initialState,
+  reducers: {
+    update: (state, action: PayloadAction<Setting>) => ({
+      ...state,
+      ...action.payload,
+    }),
+  },
+});
+
+export const { reducer } = settingsSlice;
+export const { update } = settingsSlice.actions;

--- a/src/ducks/txHistory.ts
+++ b/src/ducks/txHistory.ts
@@ -1,7 +1,7 @@
 import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
 import { DataProvider, Types } from "@stellar/wallet-sdk";
-import StellarSdk from "stellar-sdk";
-import { ActionStatus } from "./account";
+import { getNetworkConfig } from "constants/settings";
+import { ActionStatus, RejectMessage } from "constants/types.d";
 
 export const fetchTxHistoryAction = createAsyncThunk<
   Array<Types.Payment>,
@@ -9,9 +9,9 @@ export const fetchTxHistoryAction = createAsyncThunk<
   { rejectValue: RejectMessage }
 >("txHistoryAction", async (publicKey, { rejectWithValue }) => {
   const dataProvider = new DataProvider({
-    serverUrl: "https://horizon-testnet.stellar.org",
+    serverUrl: getNetworkConfig().url,
     accountOrKey: publicKey,
-    networkPassphrase: StellarSdk.Networks.TESTNET,
+    networkPassphrase: getNetworkConfig().network,
   });
   let payments: Array<Types.Payment> | null = null;
   try {
@@ -23,10 +23,6 @@ export const fetchTxHistoryAction = createAsyncThunk<
   }
   return payments;
 });
-
-interface RejectMessage {
-  errorMessage: string;
-}
 
 interface InitialTxHistoryState {
   data: Array<Types.Payment>;

--- a/src/ducks/txHistory.ts
+++ b/src/ducks/txHistory.ts
@@ -1,17 +1,21 @@
 import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
 import { DataProvider, Types } from "@stellar/wallet-sdk";
-import { getNetworkConfig } from "constants/settings";
+import { getNetworkConfig } from "helpers/getNetworkConfig";
 import { ActionStatus, RejectMessage } from "constants/types.d";
+import { isTestnetSelector } from "ducks/settings";
+import { RootState } from "App";
 
 export const fetchTxHistoryAction = createAsyncThunk<
   Array<Types.Payment>,
   string,
-  { rejectValue: RejectMessage }
->("txHistoryAction", async (publicKey, { rejectWithValue }) => {
+  { rejectValue: RejectMessage; state: RootState }
+>("txHistoryAction", async (publicKey, { rejectWithValue, getState }) => {
+  const isTestnet = isTestnetSelector(getState());
+
   const dataProvider = new DataProvider({
-    serverUrl: getNetworkConfig().url,
+    serverUrl: getNetworkConfig(isTestnet).url,
     accountOrKey: publicKey,
-    networkPassphrase: getNetworkConfig().network,
+    networkPassphrase: getNetworkConfig(isTestnet).network,
   });
   let payments: Array<Types.Payment> | null = null;
   try {

--- a/src/ducks/wallet/trezor.ts
+++ b/src/ducks/wallet/trezor.ts
@@ -2,6 +2,7 @@ import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
 // @types/trezor-connect doesn't have .stellarGetAddress()
 // @ts-ignore
 import TrezorConnect from "trezor-connect";
+import { ActionStatus, RejectMessage } from "constants/types.d";
 
 export const fetchTrezorStellarAddressAction = createAsyncThunk<
   // Return type of the payload creator
@@ -36,16 +37,6 @@ export const fetchTrezorStellarAddressAction = createAsyncThunk<
     }
   },
 );
-
-interface RejectMessage {
-  errorMessage: string;
-}
-
-export enum ActionStatus {
-  PENDING = "PENDING",
-  SUCCESS = "SUCCESS",
-  ERROR = "ERROR",
-}
 
 interface InitialState {
   data: string | null;
@@ -93,4 +84,5 @@ const walletTrezorSlice = createSlice({
   },
 });
 
-export const { reducer, actions } = walletTrezorSlice;
+export const { reducer } = walletTrezorSlice;
+export const { reset } = walletTrezorSlice.actions;

--- a/src/helpers/getNetworkConfig.ts
+++ b/src/helpers/getNetworkConfig.ts
@@ -1,0 +1,7 @@
+import { networkConfig } from "constants/settings";
+import { NetworkType } from "constants/types.d";
+
+export const getNetworkConfig = (isTestnet: boolean) => {
+  const network = isTestnet ? NetworkType.TESTNET : NetworkType.PUBLIC;
+  return networkConfig[network];
+};

--- a/src/helpers/keyManager.ts
+++ b/src/helpers/keyManager.ts
@@ -1,6 +1,7 @@
 import { KeyManager, KeyManagerPlugins, KeyType } from "@stellar/wallet-sdk";
 import { Keypair } from "stellar-sdk";
-import { getNetworkConfig } from "constants/settings";
+import { getNetworkConfig } from "helpers/getNetworkConfig";
+import { store } from "App";
 
 export interface CreateKeyManagerResponse {
   id: string;
@@ -11,10 +12,11 @@ export interface CreateKeyManagerResponse {
 const createKeyManager = () => {
   const localKeyStore = new KeyManagerPlugins.LocalStorageKeyStore();
   localKeyStore.configure({ storage: localStorage });
+  const { settings } = store.getState();
 
   const keyManager = new KeyManager({
     keyStore: localKeyStore,
-    defaultNetworkPassphrase: getNetworkConfig().network,
+    defaultNetworkPassphrase: getNetworkConfig(settings.isTestnet).network,
   });
 
   keyManager.registerEncrypter(KeyManagerPlugins.ScryptEncrypter);
@@ -24,6 +26,7 @@ const createKeyManager = () => {
 export const storePrivateKey = async (secret: string) => {
   const keyPair = Keypair.fromSecret(secret);
   const keyManager = createKeyManager();
+  const { settings } = store.getState();
 
   const result: CreateKeyManagerResponse = {
     id: "",
@@ -37,7 +40,7 @@ export const storePrivateKey = async (secret: string) => {
         type: KeyType.plaintextKey,
         publicKey: keyPair.publicKey(),
         privateKey: keyPair.secret(),
-        network: getNetworkConfig().network,
+        network: getNetworkConfig(settings.isTestnet).network,
       },
       password: result.password,
       encrypterName: KeyManagerPlugins.ScryptEncrypter.name,

--- a/src/helpers/keyManager.ts
+++ b/src/helpers/keyManager.ts
@@ -1,5 +1,6 @@
 import { KeyManager, KeyManagerPlugins, KeyType } from "@stellar/wallet-sdk";
-import { Keypair, Networks } from "stellar-sdk";
+import { Keypair } from "stellar-sdk";
+import { getNetworkConfig } from "constants/settings";
 
 export interface CreateKeyManagerResponse {
   id: string;
@@ -13,8 +14,7 @@ const createKeyManager = () => {
 
   const keyManager = new KeyManager({
     keyStore: localKeyStore,
-    // TODO - network config
-    defaultNetworkPassphrase: Networks.TESTNET,
+    defaultNetworkPassphrase: getNetworkConfig().network,
   });
 
   keyManager.registerEncrypter(KeyManagerPlugins.ScryptEncrypter);
@@ -37,8 +37,7 @@ export const storePrivateKey = async (secret: string) => {
         type: KeyType.plaintextKey,
         publicKey: keyPair.publicKey(),
         privateKey: keyPair.secret(),
-        // TODO - network config
-        network: Networks.TESTNET,
+        network: getNetworkConfig().network,
       },
       password: result.password,
       encrypterName: KeyManagerPlugins.ScryptEncrypter.name,

--- a/src/helpers/submitPaymentTransaction.ts
+++ b/src/helpers/submitPaymentTransaction.ts
@@ -1,19 +1,25 @@
-import { PaymentTransactionParams } from "ducks/sendTransaction";
 import StellarSdk, {
   Transaction,
   MemoType,
   MemoValue,
   Keypair,
 } from "stellar-sdk";
-import { getNetworkConfig } from "constants/settings";
+import { PaymentTransactionParams } from "ducks/sendTransaction";
+import { getNetworkConfig } from "helpers/getNetworkConfig";
+import { store } from "App";
 
 export const submitPaymentTransaction = async (
   params: PaymentTransactionParams,
 ) => {
-  const server = new StellarSdk.Server(getNetworkConfig().url);
+  const { settings } = store.getState();
+  const server = new StellarSdk.Server(
+    getNetworkConfig(settings.isTestnet).url,
+  );
+
   const keypair = Keypair.fromSecret(params.secret);
   let transaction = await buildPaymentTransaction(params);
   transaction = await signTransaction(transaction, keypair);
+
   const result = await server.submitTransaction(transaction);
   return result;
 };
@@ -56,14 +62,17 @@ export const buildPaymentTransaction = async ({
 }: PaymentTransactionParams) => {
   let transaction;
   try {
-    const server = new StellarSdk.Server(getNetworkConfig().url);
+    const { settings } = store.getState();
+    const server = new StellarSdk.Server(
+      getNetworkConfig(settings.isTestnet).url,
+    );
     const keypair = Keypair.fromSecret(secret);
     const sequence = (await server.loadAccount(keypair.publicKey())).sequence;
     const source = await new StellarSdk.Account(keypair.publicKey(), sequence);
 
     transaction = new StellarSdk.TransactionBuilder(source, {
       fee,
-      networkPassphrase: getNetworkConfig().network,
+      networkPassphrase: getNetworkConfig(settings.isTestnet).network,
       timebounds: await server.fetchTimebounds(100),
     }).addOperation(
       StellarSdk.Operation.payment({

--- a/src/helpers/submitPaymentTransaction.ts
+++ b/src/helpers/submitPaymentTransaction.ts
@@ -5,11 +5,12 @@ import StellarSdk, {
   MemoValue,
   Keypair,
 } from "stellar-sdk";
+import { getNetworkConfig } from "constants/settings";
 
 export const submitPaymentTransaction = async (
   params: PaymentTransactionParams,
 ) => {
-  const server = new StellarSdk.Server("https://horizon-testnet.stellar.org");
+  const server = new StellarSdk.Server(getNetworkConfig().url);
   const keypair = Keypair.fromSecret(params.secret);
   let transaction = await buildPaymentTransaction(params);
   transaction = await signTransaction(transaction, keypair);
@@ -55,14 +56,14 @@ export const buildPaymentTransaction = async ({
 }: PaymentTransactionParams) => {
   let transaction;
   try {
-    const server = new StellarSdk.Server("https://horizon-testnet.stellar.org");
+    const server = new StellarSdk.Server(getNetworkConfig().url);
     const keypair = Keypair.fromSecret(secret);
     const sequence = (await server.loadAccount(keypair.publicKey())).sequence;
     const source = await new StellarSdk.Account(keypair.publicKey(), sequence);
 
     transaction = new StellarSdk.TransactionBuilder(source, {
       fee,
-      networkPassphrase: StellarSdk.Networks.TESTNET,
+      networkPassphrase: getNetworkConfig().network,
       timebounds: await server.fetchTimebounds(100),
     }).addOperation(
       StellarSdk.Operation.payment({


### PR DESCRIPTION
- Added `constants/settings` for network configuration and any other settings the app will have.
- Added `constants/types.d.ts` for shared types.
- `?testnet=true` (or false) flag to set the network manually. Display a warning banner if the network doesn't match the environment.

![image](https://user-images.githubusercontent.com/7346473/88408197-358bbb00-cda1-11ea-9111-87e4c7aad6aa.png)
