### PR TITLE
Payments History updates

### DIFF
--- a/src/components/Network.tsx
+++ b/src/components/Network.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from "react";
 import { useLocation } from "react-router-dom";
 import { useDispatch } from "react-redux";
 import styled from "styled-components";
-import { update } from "ducks/settings";
+import { updateAction } from "ducks/settings";
 import { useRedux } from "hooks/useRedux";
 
 const BannerEl = styled.div`
@@ -32,7 +32,7 @@ export const Network = ({ children }: NetworkProps) => {
   useEffect(() => {
     if (testnetParam) {
       // route and store will reset when page reloads on query change
-      dispatch(update({ isTestnet }));
+      dispatch(updateAction({ isTestnet }));
     }
   }, [isTestnet, dispatch, testnetParam]);
 

--- a/src/components/Network.tsx
+++ b/src/components/Network.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from "react";
 import { useLocation } from "react-router-dom";
 import { useDispatch } from "react-redux";
 import styled from "styled-components";
-import { updateAction } from "ducks/settings";
+import { updateSettingsAction } from "ducks/settings";
 import { useRedux } from "hooks/useRedux";
 
 const BannerEl = styled.div`
@@ -32,7 +32,7 @@ export const Network = ({ children }: NetworkProps) => {
   useEffect(() => {
     if (testnetParam) {
       // route and store will reset when page reloads on query change
-      dispatch(updateAction({ isTestnet }));
+      dispatch(updateSettingsAction({ isTestnet }));
     }
   }, [isTestnet, dispatch, testnetParam]);
 

--- a/src/components/SigninSecretKeyForm.tsx
+++ b/src/components/SigninSecretKeyForm.tsx
@@ -4,9 +4,9 @@ import { useDispatch } from "react-redux";
 import styled from "styled-components";
 import { Keypair } from "stellar-sdk";
 
-import { fetchAccountAction, resetAction } from "ducks/account";
+import { fetchAccountAction, resetAccountAction } from "ducks/account";
 import { storePrivateKeyAction } from "ducks/keyStore";
-import { updateAction } from "ducks/settings";
+import { updateSettingsAction } from "ducks/settings";
 import { useRedux } from "hooks/useRedux";
 import { ActionStatus, AuthType } from "constants/types.d";
 
@@ -60,7 +60,7 @@ export const SigninSecretKeyForm = ({ onClose }: SigninSecretKeyFormProps) => {
     if (status === ActionStatus.SUCCESS) {
       if (isAuthenticated) {
         history.push("/dashboard");
-        dispatch(updateAction({ authType: AuthType.PRIVATE_KEY }));
+        dispatch(updateSettingsAction({ authType: AuthType.PRIVATE_KEY }));
       } else {
         setPageError("Something went wrong, please try again.");
       }
@@ -70,7 +70,7 @@ export const SigninSecretKeyForm = ({ onClose }: SigninSecretKeyFormProps) => {
   useEffect(
     () => () => {
       if (errorMessage) {
-        dispatch(resetAction());
+        dispatch(resetAccountAction());
       }
     },
     [errorMessage, dispatch],

--- a/src/components/SigninSecretKeyForm.tsx
+++ b/src/components/SigninSecretKeyForm.tsx
@@ -4,9 +4,9 @@ import { useDispatch } from "react-redux";
 import styled from "styled-components";
 import { Keypair } from "stellar-sdk";
 
-import { fetchAccountAction, reset } from "ducks/account";
+import { fetchAccountAction, resetAction } from "ducks/account";
 import { storePrivateKeyAction } from "ducks/keyStore";
-import { update } from "ducks/settings";
+import { updateAction } from "ducks/settings";
 import { useRedux } from "hooks/useRedux";
 import { ActionStatus, AuthType } from "constants/types.d";
 
@@ -60,7 +60,7 @@ export const SigninSecretKeyForm = ({ onClose }: SigninSecretKeyFormProps) => {
     if (status === ActionStatus.SUCCESS) {
       if (isAuthenticated) {
         history.push("/dashboard");
-        dispatch(update({ authType: AuthType.PRIVATE_KEY }));
+        dispatch(updateAction({ authType: AuthType.PRIVATE_KEY }));
       } else {
         setPageError("Something went wrong, please try again.");
       }
@@ -70,7 +70,7 @@ export const SigninSecretKeyForm = ({ onClose }: SigninSecretKeyFormProps) => {
   useEffect(
     () => () => {
       if (errorMessage) {
-        dispatch(reset());
+        dispatch(resetAction());
       }
     },
     [errorMessage, dispatch],

--- a/src/components/SigninSecretKeyForm.tsx
+++ b/src/components/SigninSecretKeyForm.tsx
@@ -4,7 +4,7 @@ import { useDispatch } from "react-redux";
 import styled from "styled-components";
 import { Keypair } from "stellar-sdk";
 
-import { fetchAccountAction } from "ducks/account";
+import { fetchAccountAction, reset } from "ducks/account";
 import { storePrivateKeyAction } from "ducks/keyStore";
 import { update } from "ducks/settings";
 import { useRedux } from "hooks/useRedux";
@@ -66,6 +66,15 @@ export const SigninSecretKeyForm = ({ onClose }: SigninSecretKeyFormProps) => {
       }
     }
   }, [status, errorMessage, dispatch, history, isAuthenticated]);
+
+  useEffect(
+    () => () => {
+      if (errorMessage) {
+        dispatch(reset());
+      }
+    },
+    [errorMessage, dispatch],
+  );
 
   let failedAttempts = 0;
 

--- a/src/components/SigninTrezorForm.tsx
+++ b/src/components/SigninTrezorForm.tsx
@@ -70,8 +70,7 @@ export const SigninTrezorForm = ({ onClose }: SigninTrezorFormProps) => {
 
   const initTrezor = () => {
     TrezorConnect.manifest({
-      // TODO: Email to use to be contacted by Trezor for maintenance, etc.
-      email: "info@stellar.org",
+      email: "accounts+trezor@stellar.org",
       appUrl: "https://accountviewer.stellar.org/",
     });
 

--- a/src/components/SigninTrezorForm.tsx
+++ b/src/components/SigninTrezorForm.tsx
@@ -6,11 +6,14 @@ import { useDispatch } from "react-redux";
 // @ts-ignore
 import TrezorConnect from "trezor-connect";
 
-import { fetchAccountAction, reset as resetAccount } from "ducks/account";
-import { update } from "ducks/settings";
+import {
+  fetchAccountAction,
+  resetAction as resetAccountAction,
+} from "ducks/account";
+import { updateAction } from "ducks/settings";
 import {
   fetchTrezorStellarAddressAction,
-  reset as resetTrezor,
+  resetAction as resetTrezorAction,
 } from "ducks/wallet/trezor";
 import { useRedux } from "hooks/useRedux";
 import { ActionStatus, AuthType } from "constants/types.d";
@@ -80,8 +83,8 @@ export const SigninTrezorForm = ({ onClose }: SigninTrezorFormProps) => {
   useEffect(
     () => () => {
       if (pageError) {
-        dispatch(resetTrezor());
-        dispatch(resetAccount());
+        dispatch(resetTrezorAction());
+        dispatch(resetAccountAction());
       }
     },
     [dispatch, pageError],
@@ -115,7 +118,7 @@ export const SigninTrezorForm = ({ onClose }: SigninTrezorFormProps) => {
     if (accountStatus === ActionStatus.SUCCESS) {
       if (isAuthenticated) {
         history.push("/dashboard");
-        dispatch(update({ authType: AuthType.TREZOR }));
+        dispatch(updateAction({ authType: AuthType.TREZOR }));
       } else {
         setPageError("Something went wrong, please try again.");
       }

--- a/src/components/SigninTrezorForm.tsx
+++ b/src/components/SigninTrezorForm.tsx
@@ -6,14 +6,11 @@ import { useDispatch } from "react-redux";
 // @ts-ignore
 import TrezorConnect from "trezor-connect";
 
-import {
-  fetchAccountAction,
-  resetAction as resetAccountAction,
-} from "ducks/account";
-import { updateAction } from "ducks/settings";
+import { fetchAccountAction, resetAccountAction } from "ducks/account";
+import { updateSettingsAction } from "ducks/settings";
 import {
   fetchTrezorStellarAddressAction,
-  resetAction as resetTrezorAction,
+  resetTrezorAction,
 } from "ducks/wallet/trezor";
 import { useRedux } from "hooks/useRedux";
 import { ActionStatus, AuthType } from "constants/types.d";
@@ -118,7 +115,7 @@ export const SigninTrezorForm = ({ onClose }: SigninTrezorFormProps) => {
     if (accountStatus === ActionStatus.SUCCESS) {
       if (isAuthenticated) {
         history.push("/dashboard");
-        dispatch(updateAction({ authType: AuthType.TREZOR }));
+        dispatch(updateSettingsAction({ authType: AuthType.TREZOR }));
       } else {
         setPageError("Something went wrong, please try again.");
       }

--- a/src/components/TransactionHistory.tsx
+++ b/src/components/TransactionHistory.tsx
@@ -51,7 +51,13 @@ export const TransactionHistory = () => {
   const dispatch = useDispatch();
   const [showAllTxs, setShowAllTxs] = useState(false);
   const [pageError, setPageError] = useState("");
-  const { status, data, isTxWatcherStarted, errorMessage } = txHistory;
+  const {
+    status,
+    data,
+    isTxWatcherStarted,
+    errorMessage,
+    hasMoreTx,
+  } = txHistory;
 
   useEffect(() => {
     if (accountId) {
@@ -130,15 +136,17 @@ export const TransactionHistory = () => {
               </ItemRowEl>
             ))}
           </El>
-          <El>
-            <a
-              href={`${
-                getNetworkConfig(settings.isTestnet).stellarExpertAccountUrl
-              }${accountId}`}
-            >
-              View full list of transactions
-            </a>
-          </El>
+          {hasMoreTx && (
+            <El>
+              <a
+                href={`${
+                  getNetworkConfig(settings.isTestnet).stellarExpertAccountUrl
+                }${accountId}`}
+              >
+                View full list of transactions
+              </a>
+            </El>
+          )}
         </>
       )}
     </El>

--- a/src/constants/settings.ts
+++ b/src/constants/settings.ts
@@ -1,9 +1,14 @@
 import StellarSdk from "stellar-sdk";
 
+// TODO: set to 100 before launch
+export const TX_HISTORY_LIMIT = 20;
+export const TX_HISTORY_MIN_AMOUNT = 0.5;
+
 interface NetworkItemConfig {
   url: string;
   network: string;
   stellarExpertTxUrl: string;
+  stellarExpertAccountUrl: string;
 }
 
 interface NetworkConfig {
@@ -16,10 +21,12 @@ export const networkConfig: NetworkConfig = {
     url: "https://horizon-testnet.stellar.org",
     network: StellarSdk.Networks.TESTNET,
     stellarExpertTxUrl: "https://stellar.expert/explorer/testnet/tx/",
+    stellarExpertAccountUrl: "https://stellar.expert/explorer/testnet/account/",
   },
   public: {
     url: "https://horizon.stellar.org",
     network: StellarSdk.Networks.PUBLIC,
     stellarExpertTxUrl: "https://stellar.expert/explorer/public/tx/",
+    stellarExpertAccountUrl: "https://stellar.expert/explorer/public/account/",
   },
 };

--- a/src/ducks/account.ts
+++ b/src/ducks/account.ts
@@ -55,9 +55,8 @@ const accountSlice = createSlice({
     reset: () => initialState,
   },
   extraReducers: (builder) => {
-    builder.addCase(fetchAccountAction.pending, (state) => ({
-      ...state,
-      data: null,
+    builder.addCase(fetchAccountAction.pending, () => ({
+      ...initialState,
       status: ActionStatus.PENDING,
     }));
 

--- a/src/ducks/account.ts
+++ b/src/ducks/account.ts
@@ -52,7 +52,7 @@ const accountSlice = createSlice({
   name: "account",
   initialState,
   reducers: {
-    resetAction: () => initialState,
+    resetAccountAction: () => initialState,
   },
   extraReducers: (builder) => {
     builder.addCase(fetchAccountAction.pending, () => ({
@@ -79,4 +79,4 @@ const accountSlice = createSlice({
 });
 
 export const { reducer } = accountSlice;
-export const { resetAction } = accountSlice.actions;
+export const { resetAccountAction } = accountSlice.actions;

--- a/src/ducks/account.ts
+++ b/src/ducks/account.ts
@@ -52,7 +52,7 @@ const accountSlice = createSlice({
   name: "account",
   initialState,
   reducers: {
-    reset: () => initialState,
+    resetAction: () => initialState,
   },
   extraReducers: (builder) => {
     builder.addCase(fetchAccountAction.pending, () => ({
@@ -79,4 +79,4 @@ const accountSlice = createSlice({
 });
 
 export const { reducer } = accountSlice;
-export const { reset } = accountSlice.actions;
+export const { resetAction } = accountSlice.actions;

--- a/src/ducks/settings.ts
+++ b/src/ducks/settings.ts
@@ -20,7 +20,7 @@ const settingsSlice = createSlice({
   name: "settings",
   initialState,
   reducers: {
-    updateAction: (state, action: PayloadAction<Setting>) => ({
+    updateSettingsAction: (state, action: PayloadAction<Setting>) => ({
       ...state,
       ...action.payload,
     }),
@@ -30,4 +30,4 @@ const settingsSlice = createSlice({
 export const settingsSelector = (state: RootState) => state.settings;
 
 export const { reducer } = settingsSlice;
-export const { updateAction } = settingsSlice.actions;
+export const { updateSettingsAction } = settingsSlice.actions;

--- a/src/ducks/settings.ts
+++ b/src/ducks/settings.ts
@@ -20,7 +20,7 @@ const settingsSlice = createSlice({
   name: "settings",
   initialState,
   reducers: {
-    update: (state, action: PayloadAction<Setting>) => ({
+    updateAction: (state, action: PayloadAction<Setting>) => ({
       ...state,
       ...action.payload,
     }),
@@ -30,4 +30,4 @@ const settingsSlice = createSlice({
 export const settingsSelector = (state: RootState) => state.settings;
 
 export const { reducer } = settingsSlice;
-export const { update } = settingsSlice.actions;
+export const { updateAction } = settingsSlice.actions;

--- a/src/ducks/txHistory.ts
+++ b/src/ducks/txHistory.ts
@@ -2,11 +2,17 @@ import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
 import { DataProvider, Types } from "@stellar/wallet-sdk";
 import { getNetworkConfig } from "helpers/getNetworkConfig";
 import { ActionStatus, RejectMessage } from "constants/types.d";
+import { TX_HISTORY_LIMIT } from "constants/settings";
 import { settingsSelector } from "ducks/settings";
 import { RootState } from "config/store";
 
+let txHistoryWatcherStopper: any;
+
 export const fetchTxHistoryAction = createAsyncThunk<
-  Array<Types.Payment>,
+  {
+    data: Array<Types.Payment>;
+    hasMoreTxs: boolean;
+  },
   string,
   { rejectValue: RejectMessage; state: RootState }
 >("txHistoryAction", async (publicKey, { rejectWithValue, getState }) => {
@@ -17,25 +23,79 @@ export const fetchTxHistoryAction = createAsyncThunk<
     accountOrKey: publicKey,
     networkPassphrase: getNetworkConfig(isTestnet).network,
   });
-  let payments: Array<Types.Payment> | null = null;
+  let data: Array<Types.Payment> | null = null;
+  let hasMoreTxs = false;
+
   try {
-    payments = (await dataProvider.fetchPayments())?.records;
+    const transactions = await dataProvider.fetchPayments({
+      limit: TX_HISTORY_LIMIT,
+    });
+    hasMoreTxs = (await transactions.next())?.records.length > 0;
+    data = transactions?.records;
   } catch (error) {
     return rejectWithValue({
       errorMessage: error.response?.detail || error.toString(),
     });
   }
-  return payments;
+
+  return {
+    data,
+    hasMoreTxs,
+  };
 });
+
+export const startTxHistoryWatcherAction = createAsyncThunk<
+  boolean,
+  string,
+  { rejectValue: RejectMessage; state: RootState }
+>(
+  "txHistoryWatcherAction",
+  (publicKey, { rejectWithValue, getState, dispatch }) => {
+    try {
+      const { isTestnet } = settingsSelector(getState());
+      const { data } = txHistorySelector(getState());
+
+      const dataProvider = new DataProvider({
+        serverUrl: getNetworkConfig(isTestnet).url,
+        accountOrKey: publicKey,
+        networkPassphrase: getNetworkConfig(isTestnet).network,
+      });
+
+      txHistoryWatcherStopper = dataProvider.watchPayments({
+        onMessage: (payment: Types.Payment) => {
+          // Update only if there are newer transactions
+          if (!data[0] || payment.timestamp > data[0]?.timestamp) {
+            dispatch(updateTxHistoryAction(payment));
+          }
+        },
+        onError: (error) => {
+          const errorMessage =
+            error?.toString() || "We couldn't update your payments history";
+          dispatch(updateTxHistoryErrorAction({ errorMessage, data }));
+        },
+      });
+
+      return true;
+    } catch (error) {
+      return rejectWithValue({
+        errorMessage: error.response?.detail || error.toString(),
+      });
+    }
+  },
+);
 
 interface InitialTxHistoryState {
   data: Array<Types.Payment>;
+  hasMoreTxs?: boolean;
+  isTxWatcherStarted: boolean;
   errorMessage?: string;
   status: ActionStatus | undefined;
 }
 
 const initialTxHistoryState: InitialTxHistoryState = {
   data: [],
+  hasMoreTxs: false,
+  isTxWatcherStarted: false,
   errorMessage: undefined,
   status: undefined,
 };
@@ -43,7 +103,26 @@ const initialTxHistoryState: InitialTxHistoryState = {
 export const txHistorySlice = createSlice({
   name: "txHistory",
   initialState: initialTxHistoryState,
-  reducers: {},
+  reducers: {
+    updateTxHistoryAction: (state, action) => ({
+      ...state,
+      data: [action.payload, ...state.data],
+    }),
+    updateTxHistoryErrorAction: (state, action) => ({
+      ...state,
+      // TODO: temp solution to pass "data" until BigNumber issue is fixed
+      data: action.payload.data,
+      status: ActionStatus.ERROR,
+      errorMessage: action.payload.errorMessage,
+    }),
+    stopTxHistoryWatcherAction: () => {
+      if (txHistoryWatcherStopper) {
+        txHistoryWatcherStopper();
+      }
+
+      return initialTxHistoryState;
+    },
+  },
   extraReducers: (builder) => {
     builder.addCase(fetchTxHistoryAction.pending, (state) => ({
       ...state,
@@ -52,7 +131,8 @@ export const txHistorySlice = createSlice({
     }));
     builder.addCase(fetchTxHistoryAction.fulfilled, (state, action) => ({
       ...state,
-      data: action.payload,
+      data: action.payload.data,
+      hasMoreTxs: action.payload.hasMoreTxs,
       status: ActionStatus.SUCCESS,
     }));
     builder.addCase(fetchTxHistoryAction.rejected, (state, action) => ({
@@ -61,7 +141,28 @@ export const txHistorySlice = createSlice({
       status: ActionStatus.ERROR,
       errorMessage: action.payload?.errorMessage,
     }));
+
+    // TODO: figure out why it breaks for BigNumber amount
+    // @ts-ignore
+    builder.addCase(startTxHistoryWatcherAction.fulfilled, (state, action) => ({
+      ...state,
+      isTxWatcherStarted: action.payload,
+    }));
+
+    // @ts-ignore
+    builder.addCase(startTxHistoryWatcherAction.rejected, (state, action) => ({
+      ...state,
+      status: ActionStatus.ERROR,
+      errorMessage: action.payload?.errorMessage,
+    }));
   },
 });
 
+export const txHistorySelector = (state: RootState) => state.txHistory;
+
 export const { reducer } = txHistorySlice;
+export const {
+  updateTxHistoryAction,
+  updateTxHistoryErrorAction,
+  stopTxHistoryWatcherAction,
+} = txHistorySlice.actions;

--- a/src/ducks/wallet/trezor.ts
+++ b/src/ducks/wallet/trezor.ts
@@ -51,7 +51,7 @@ const walletTrezorSlice = createSlice({
   name: "walletTrezor",
   initialState,
   reducers: {
-    resetAction: () => initialState,
+    resetTrezorAction: () => initialState,
   },
   extraReducers: (builder) => {
     builder.addCase(fetchTrezorStellarAddressAction.pending, (state) => ({
@@ -82,4 +82,4 @@ const walletTrezorSlice = createSlice({
 });
 
 export const { reducer } = walletTrezorSlice;
-export const { resetAction } = walletTrezorSlice.actions;
+export const { resetTrezorAction } = walletTrezorSlice.actions;

--- a/src/ducks/wallet/trezor.ts
+++ b/src/ducks/wallet/trezor.ts
@@ -51,7 +51,7 @@ const walletTrezorSlice = createSlice({
   name: "walletTrezor",
   initialState,
   reducers: {
-    reset: () => initialState,
+    resetAction: () => initialState,
   },
   extraReducers: (builder) => {
     builder.addCase(fetchTrezorStellarAddressAction.pending, (state) => ({
@@ -82,4 +82,4 @@ const walletTrezorSlice = createSlice({
 });
 
 export const { reducer } = walletTrezorSlice;
-export const { reset } = walletTrezorSlice.actions;
+export const { resetAction } = walletTrezorSlice.actions;


### PR DESCRIPTION
- History watcher added.
- Handling errors and empty states in History component.
- Limit how many transactions are shown (currently set to 20 for easier testing but will be 100 in production).
- Show link to view more transactions on StellarExpert if there are more than limit.
- Option to filter out small transactions (min 0.5).
- Unrelated quick fixes: add Trezor email, reset Sign in with Secret Key state to clear errors.

NOTE: Opened issue to investigate TypeScript error in state data: https://github.com/stellar/account-viewer-next/issues/60