### PR TITLE
Sign out functionality added

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@reduxjs/toolkit": "^1.4.0",
-    "@stellar/wallet-sdk": "^0.1.0-rc.7",
+    "@stellar/wallet-sdk": "^0.1.0-rc.9",
     "@types/qrcode.react": "^1.0.1",
     "bignumber.js": "^9.0.0",
     "lodash": "^4.17.17",

--- a/src/config/store.ts
+++ b/src/config/store.ts
@@ -2,9 +2,13 @@ import {
   configureStore,
   getDefaultMiddleware,
   isPlain,
+  createAction,
+  CombinedState,
 } from "@reduxjs/toolkit";
 import { combineReducers, Action } from "redux";
 import BigNumber from "bignumber.js";
+
+import { RESET_STORE_ACTION_TYPE } from "constants/settings";
 
 import { reducer as account } from "ducks/account";
 import { reducer as keyStore } from "ducks/keyStore";
@@ -27,15 +31,24 @@ const loggerMiddleware = (store: any) => (next: any) => (
 const isSerializable = (value: any) =>
   BigNumber.isBigNumber(value) || isPlain(value);
 
+const reducers = combineReducers({
+  account,
+  keyStore,
+  sendTx,
+  settings,
+  txHistory,
+  walletTrezor,
+});
+
+export const resetStoreAction = createAction(RESET_STORE_ACTION_TYPE);
+
+const rootReducer = (state: CombinedState<any>, action: Action) => {
+  const newState = action.type === RESET_STORE_ACTION_TYPE ? undefined : state;
+  return reducers(newState, action);
+};
+
 export const store = configureStore({
-  reducer: combineReducers({
-    account,
-    keyStore,
-    sendTx,
-    settings,
-    txHistory,
-    walletTrezor,
-  }),
+  reducer: rootReducer,
   middleware: [
     ...getDefaultMiddleware({
       serializableCheck: {

--- a/src/constants/settings.ts
+++ b/src/constants/settings.ts
@@ -3,6 +3,7 @@ import StellarSdk from "stellar-sdk";
 // TODO: set to 100 before launch
 export const TX_HISTORY_LIMIT = 20;
 export const TX_HISTORY_MIN_AMOUNT = 0.5;
+export const RESET_STORE_ACTION_TYPE = "RESET";
 
 interface NetworkItemConfig {
   url: string;

--- a/src/ducks/account.ts
+++ b/src/ducks/account.ts
@@ -73,7 +73,7 @@ export const startAccountWatcherAction = createAsyncThunk<
   },
 );
 
-interface InitialState {
+interface AccountInitialState {
   data: Types.AccountDetails | null;
   isAuthenticated: boolean;
   isAccountWatcherStarted: boolean;
@@ -81,7 +81,7 @@ interface InitialState {
   errorString?: string;
 }
 
-const initialState: InitialState = {
+const initialState: AccountInitialState = {
   data: null,
   isAuthenticated: false,
   isAccountWatcherStarted: false,
@@ -108,6 +108,7 @@ const accountSlice = createSlice({
     stopAccountWatcherAction: () => {
       if (accountWatcherStopper) {
         accountWatcherStopper();
+        accountWatcherStopper = undefined;
       }
 
       return initialState;

--- a/src/ducks/keyStore.ts
+++ b/src/ducks/keyStore.ts
@@ -29,13 +29,13 @@ export const storeKeyAction = createAsyncThunk<
   },
 );
 
-interface InitialState {
+interface KeyStoreInitialState {
   keyStoreId: string;
   password: string;
   errorString?: string;
 }
 
-const initialState: InitialState = {
+const initialState: KeyStoreInitialState = {
   keyStoreId: "",
   password: "",
   errorString: undefined,

--- a/src/ducks/sendTransaction.ts
+++ b/src/ducks/sendTransaction.ts
@@ -32,13 +32,13 @@ export const sendTxAction = createAsyncThunk<
   return result;
 });
 
-interface InitialState {
+interface SendTxInitialState {
   data: Horizon.TransactionResponse | null;
   status: ActionStatus | undefined;
   errorString?: string;
 }
 
-const initialState: InitialState = {
+const initialState: SendTxInitialState = {
   data: null,
   status: undefined,
   errorString: undefined,

--- a/src/ducks/settings.ts
+++ b/src/ducks/settings.ts
@@ -2,7 +2,7 @@ import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { AuthType } from "constants/types.d";
 import { RootState } from "config/store";
 
-interface InitialState {
+interface SettingsInitialState {
   authType: AuthType | undefined;
   isTestnet: boolean;
 }
@@ -11,7 +11,7 @@ interface Setting {
   [key: string]: any;
 }
 
-const initialState: InitialState = {
+const initialState: SettingsInitialState = {
   authType: undefined,
   isTestnet: process.env.NODE_ENV === "development",
 };

--- a/src/ducks/txHistory.ts
+++ b/src/ducks/txHistory.ts
@@ -96,7 +96,7 @@ export const startTxHistoryWatcherAction = createAsyncThunk<
   },
 );
 
-interface InitialTxHistoryState {
+interface TxHistoryInitialState {
   data: Array<Types.Payment>;
   hasMoreTxs?: boolean;
   isTxWatcherStarted: boolean;
@@ -104,7 +104,7 @@ interface InitialTxHistoryState {
   status: ActionStatus | undefined;
 }
 
-const initialTxHistoryState: InitialTxHistoryState = {
+const initialTxHistoryState: TxHistoryInitialState = {
   data: [],
   hasMoreTxs: false,
   isTxWatcherStarted: false,
@@ -130,6 +130,7 @@ export const txHistorySlice = createSlice({
     stopTxHistoryWatcherAction: () => {
       if (txHistoryWatcherStopper) {
         txHistoryWatcherStopper();
+        txHistoryWatcherStopper = undefined;
       }
 
       return initialTxHistoryState;

--- a/src/ducks/wallet/trezor.ts
+++ b/src/ducks/wallet/trezor.ts
@@ -34,13 +34,13 @@ export const fetchTrezorStellarAddressAction = createAsyncThunk<
   },
 );
 
-interface InitialState {
+interface WalletTrezorInitialState {
   data: string | null;
   status: ActionStatus | undefined;
   errorString?: string;
 }
 
-const initialState: InitialState = {
+const initialState: WalletTrezorInitialState = {
   data: null,
   status: undefined,
   errorString: undefined,

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,5 +1,9 @@
 import React from "react";
 import styled from "styled-components";
+import { useDispatch } from "react-redux";
+import { resetStoreAction } from "config/store";
+import { stopAccountWatcherAction } from "ducks/account";
+import { stopTxHistoryWatcherAction } from "ducks/txHistory";
 import { useRedux } from "hooks/useRedux";
 import { BalanceInfo } from "components/BalanceInfo";
 import { TransactionHistory } from "components/TransactionHistory";
@@ -8,13 +12,25 @@ const El = styled.div`
   padding-bottom: 10px;
 `;
 
+const TempButtonEl = styled.button`
+  margin-bottom: 20px;
+`;
+
 export const Dashboard = () => {
+  const dispatch = useDispatch();
   const { account } = useRedux(["account"]);
+
+  const handleSignOut = () => {
+    dispatch(stopAccountWatcherAction());
+    dispatch(stopTxHistoryWatcherAction());
+    dispatch(resetStoreAction());
+  };
 
   return (
     <El>
       <h1>Dashboard</h1>
       <El>{account.data.id}</El>
+      <TempButtonEl onClick={handleSignOut}>Sign out</TempButtonEl>
 
       <BalanceInfo />
       <TransactionHistory />

--- a/yarn.lock
+++ b/yarn.lock
@@ -1449,10 +1449,10 @@
   resolved "https://registry.yarnpkg.com/@stellar/tsconfig/-/tsconfig-1.0.2.tgz#18e9b1a1d6076e116bb405d11fc034401155292d"
   integrity sha512-lC51QSlYRM8K3oGe0/WGPq+p9+u+yPzwZXSKrZXKOe4sq79vzfiqFbQyp5enOffFzXlahcDyTgY67mBOkJytfw==
 
-"@stellar/wallet-sdk@^0.1.0-rc.7":
-  version "0.1.0-rc.7"
-  resolved "https://registry.yarnpkg.com/@stellar/wallet-sdk/-/wallet-sdk-0.1.0-rc.7.tgz#c01f1d52d837149027fc229e63d9224580de8608"
-  integrity sha512-48Xqn1TZyHnKBxjSgqknnMqtNd10EvK7xIiTCPUi1uENhtl14KJdgrmV1mMy61ZYzySL1FrvJs4X9cddXTHaRQ==
+"@stellar/wallet-sdk@^0.1.0-rc.9":
+  version "0.1.0-rc.9"
+  resolved "https://registry.yarnpkg.com/@stellar/wallet-sdk/-/wallet-sdk-0.1.0-rc.9.tgz#79ba2cac0904bbf2977fe9ee5cbfeba9d148e39e"
+  integrity sha512-WbehcGjIcIHlxMTQ9iljBtJFDJPGMgvVregxCBR8pl1lX1QE+NV/Q9mZgeDtGXK7UyMFiTk2q3L0bNNU+SGmZQ==
   dependencies:
     "@ledgerhq/hw-app-str" "^4.48.0"
     "@ledgerhq/hw-transport-u2f" "^4.48.0"


### PR DESCRIPTION
- Add "Sign out" action.
- Reset the whole store and stop all watchers when signed out.
- Add unique names to action initial states (not used directly but helpful to see it in TypeScript types).
- Upgrade `wallet-sdk` to 0.1.0-rc.9 to fix History transactions stopper.