### PR TITLE
Add Albedo wallet

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,7 +4,5 @@ module.exports = {
     "no-console": 0,
     "import/no-unresolved": "off",
     "react/jsx-filename-extension": [1, { extensions: [".tsx", ".jsx"] }],
-    // TODO: remove once @stellar/eslint-config is updated
-    "no-param-reassign": 0,
   },
 };

--- a/package.json
+++ b/package.json
@@ -14,11 +14,12 @@
     ]
   },
   "dependencies": {
+    "@albedo-link/intent": "^0.9.0",
     "@ledgerhq/hw-app-str": "^5.21.0",
     "@ledgerhq/hw-transport-u2f": "^5.21.0",
     "@reduxjs/toolkit": "^1.4.0",
-    "@types/ledgerhq__hw-transport-u2f": "^4.21.1",
     "@stellar/wallet-sdk": "^0.1.0-rc.9",
+    "@types/ledgerhq__hw-transport-u2f": "^4.21.1",
     "@types/qrcode.react": "^1.0.1",
     "bignumber.js": "^9.0.0",
     "lodash": "^4.17.17",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@ledgerhq/hw-transport-u2f": "^5.21.0",
     "@reduxjs/toolkit": "^1.4.0",
     "@stellar/lyra-api": "^1.0.0-alpha.2",
-    "@stellar/wallet-sdk": "^0.1.0-rc.10",
+    "@stellar/wallet-sdk": "^0.1.0-rc.11",
     "@types/ledgerhq__hw-transport-u2f": "^4.21.1",
     "@types/qrcode.react": "^1.0.1",
     "bignumber.js": "^9.0.0",
@@ -64,7 +64,7 @@
     ]
   },
   "devDependencies": {
-    "@stellar/eslint-config": "^1.0.4",
+    "@stellar/eslint-config": "^1.0.5",
     "@stellar/prettier-config": "^1.0.1",
     "@stellar/tsconfig": "^1.0.2",
     "@testing-library/jest-dom": "^4.2.4",

--- a/src/components/SignIn/SignInAlbedoForm.tsx
+++ b/src/components/SignIn/SignInAlbedoForm.tsx
@@ -1,0 +1,122 @@
+import React, { useEffect } from "react";
+import styled from "styled-components";
+import { useHistory } from "react-router-dom";
+import { useDispatch } from "react-redux";
+import { KeyType } from "@stellar/wallet-sdk";
+
+import { fetchAccountAction, resetAccountAction } from "ducks/account";
+import { storeKeyAction } from "ducks/keyStore";
+import { updateSettingsAction } from "ducks/settings";
+import {
+  fetchAlbedoStellarAddressAction,
+  resetAlbedoAction,
+} from "ducks/wallet/albedo";
+import { useErrorMessage } from "hooks/useErrorMessage";
+import { useRedux } from "hooks/useRedux";
+import { ActionStatus, AuthType, ModalPageProps } from "constants/types.d";
+import { ErrorMessage } from "components/ErrorMessage";
+
+const InfoEl = styled.div`
+  background-color: #dbdbdb;
+  padding: 20px;
+  margin-bottom: 20px;
+`;
+
+const TempButtonEl = styled.button`
+  margin-bottom: 20px;
+`;
+
+const TempLinkButtonEl = styled.div`
+  margin-bottom: 20px;
+  text-decoration: underline;
+  cursor: pointer;
+`;
+
+export const SignInAlbedoForm = ({ onClose }: ModalPageProps) => {
+  const history = useHistory();
+  const dispatch = useDispatch();
+
+  const { walletAlbedo, account } = useRedux(["walletAlbedo", "account"]);
+  const {
+    data: albedoData,
+    status: albedoStatus,
+    errorString: albedoErrorMessage,
+  } = walletAlbedo;
+  const {
+    status: accountStatus,
+    isAuthenticated,
+    errorString: accountErrorMessage,
+  } = account;
+
+  const { errorMessage, setErrorMessage } = useErrorMessage({
+    initialMessage: albedoErrorMessage || accountErrorMessage,
+    onUnmount: () => {
+      dispatch(resetAlbedoAction());
+      dispatch(resetAccountAction());
+    },
+  });
+
+  const fetchAlbedoLogin = () => {
+    setErrorMessage("");
+
+    try {
+      dispatch(fetchAlbedoStellarAddressAction());
+    } catch (e) {
+      setErrorMessage(`Something went wrong. ${e.toString()}`);
+    }
+  };
+
+  useEffect(() => {
+    if (albedoStatus === ActionStatus.SUCCESS) {
+      if (albedoData) {
+        try {
+          dispatch(fetchAccountAction(albedoData.publicKey));
+          dispatch(
+            storeKeyAction({
+              publicKey: albedoData.publicKey,
+              keyType: KeyType.albedo,
+            }),
+          );
+        } catch (e) {
+          setErrorMessage(`Something went wrong. ${e.toString()}`);
+        }
+      } else {
+        setErrorMessage("Something went wrong, please try again.");
+      }
+    }
+  }, [albedoStatus, dispatch, albedoData, setErrorMessage]);
+
+  useEffect(() => {
+    if (accountStatus === ActionStatus.SUCCESS) {
+      if (isAuthenticated) {
+        history.push("/dashboard");
+        dispatch(updateSettingsAction({ authType: AuthType.ALBEDO }));
+      } else {
+        setErrorMessage("Something went wrong, please try again.");
+      }
+    }
+  }, [accountStatus, dispatch, history, isAuthenticated, setErrorMessage]);
+
+  return (
+    <div>
+      <h1>Sign in with Albedo</h1>
+
+      {!albedoStatus && (
+        <>
+          <InfoEl>Some instructions</InfoEl>
+          <TempButtonEl onClick={fetchAlbedoLogin}>
+            Sign in with Albedo
+          </TempButtonEl>
+        </>
+      )}
+
+      {albedoStatus === ActionStatus.PENDING && (
+        <InfoEl>Please follow the instructions in the Albedo popup.</InfoEl>
+      )}
+
+      <ErrorMessage message={errorMessage} />
+
+      <TempLinkButtonEl onClick={onClose}>Cancel</TempLinkButtonEl>
+    </div>
+  );
+};

--- a/src/config/store.ts
+++ b/src/config/store.ts
@@ -15,8 +15,9 @@ import { reducer as keyStore } from "ducks/keyStore";
 import { reducer as sendTx } from "ducks/sendTransaction";
 import { reducer as settings } from "ducks/settings";
 import { reducer as txHistory } from "ducks/txHistory";
-import { reducer as walletTrezor } from "ducks/wallet/trezor";
+import { reducer as walletAlbedo } from "ducks/wallet/albedo";
 import { reducer as walletLedger } from "ducks/wallet/ledger";
+import { reducer as walletTrezor } from "ducks/wallet/trezor";
 
 export type RootState = ReturnType<typeof store.getState>;
 
@@ -38,8 +39,9 @@ const reducers = combineReducers({
   sendTx,
   settings,
   txHistory,
-  walletTrezor,
+  walletAlbedo,
   walletLedger,
+  walletTrezor,
 });
 
 export const resetStoreAction = createAction(RESET_STORE_ACTION_TYPE);

--- a/src/constants/@modules.d.ts
+++ b/src/constants/@modules.d.ts
@@ -1,1 +1,2 @@
+declare module "@albedo-link/intent";
 declare module "@ledgerhq/hw-app-str";

--- a/src/ducks/wallet/albedo.ts
+++ b/src/ducks/wallet/albedo.ts
@@ -1,0 +1,70 @@
+import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
+import albedo from "@albedo-link/intent";
+
+import {
+  ActionStatus,
+  RejectMessage,
+  WalletInitialState,
+} from "constants/types.d";
+
+export const fetchAlbedoStellarAddressAction = createAsyncThunk<
+  { publicKey: string },
+  undefined,
+  { rejectValue: RejectMessage }
+>(
+  "walletAlbedo/fetchAlbedoStellarAddressAction",
+  async (_, { rejectWithValue }) => {
+    try {
+      const albedoResponse = await albedo.publicKey();
+
+      return { publicKey: albedoResponse.pubkey };
+    } catch (error) {
+      return rejectWithValue({
+        errorString: error.message || error.toString(),
+      });
+    }
+  },
+);
+
+const initialState: WalletInitialState = {
+  data: null,
+  status: undefined,
+  errorString: undefined,
+};
+
+const walletAlbedoSlice = createSlice({
+  name: "walletAlbedo",
+  initialState,
+  reducers: {
+    resetAlbedoAction: () => initialState,
+  },
+  extraReducers: (builder) => {
+    builder.addCase(fetchAlbedoStellarAddressAction.pending, (state) => ({
+      ...state,
+      data: null,
+      status: ActionStatus.PENDING,
+    }));
+
+    builder.addCase(
+      fetchAlbedoStellarAddressAction.fulfilled,
+      (state, action) => ({
+        ...state,
+        data: action.payload,
+        status: ActionStatus.SUCCESS,
+      }),
+    );
+
+    builder.addCase(
+      fetchAlbedoStellarAddressAction.rejected,
+      (state, action) => ({
+        ...state,
+        data: null,
+        status: ActionStatus.ERROR,
+        errorString: action.payload?.errorString,
+      }),
+    );
+  },
+});
+
+export const { reducer } = walletAlbedoSlice;
+export const { resetAlbedoAction } = walletAlbedoSlice.actions;

--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -6,6 +6,7 @@ import { NewKeyPairForm } from "components/NewKeyPairForm";
 import { SignInSecretKeyForm } from "components/SignIn/SignInSecretKeyForm";
 import { SignInTrezorForm } from "components/SignIn/SignInTrezorForm";
 import { SignInLedgerForm } from "components/SignIn/SignInLedgerForm";
+import { SignInAlbedoForm } from "components/SignIn/SignInAlbedoForm";
 
 const TempLinkButtonEl = styled.div`
   margin-bottom: 20px;
@@ -44,7 +45,7 @@ export const Landing = () => {
       case ModalType.SIGNIN_LYRA:
         return <div>Lyra</div>;
       case ModalType.SIGNIN_ALBEDO:
-        return <div>Albedo</div>;
+        return <SignInAlbedoForm onClose={closeModal} />;
       case ModalType.NEW_KEY_PAIR:
         return <NewKeyPairForm onClose={closeModal} />;
       default:

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,6 +7,11 @@
   resolved "https://registry.yarnpkg.com/@albedo-link/intent/-/intent-0.9.0.tgz#cc5b6e2822b4f1b2c78be334e9fe82f9facf11f7"
   integrity sha512-NYxJCJebB7oFtycS/GID0z+/IIYE+OGAzk14nqUy8N9FegcjKyFngQisRswXM8FZLrLmHO5lv643Qx3YE4PX0g==
 
+"@albedo-link/intent@^0.9.2":
+  version "0.9.2"
+  resolved "https://registry.yarnpkg.com/@albedo-link/intent/-/intent-0.9.2.tgz#64d198a3a8fb4ed70ab17dee555f2fe59f5dcac6"
+  integrity sha512-toETcSL3seYeNvP9mxUdzpJ/7UxekF6+XrqnFWrlT7Khwne/ufEE2+kT7Zqc4Zp2awNZZtlyKzTdLEud4c+uEw==
+
 "@babel/code-frame@7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.8.3.tgz#33e25903d7481181534e12ec0a25f16b6fcf419e"
@@ -1530,10 +1535,10 @@
   resolved "https://registry.yarnpkg.com/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.3.tgz#5405ee8e444ed212db44e79351f0c70a582aae25"
   integrity sha512-DetpxZw1fzPD5xUBrIAoplLChO2VB8DlL5Gg+I1IR9b2wPqYIca2WSUxL5g1vLeR4MsQq1NeWriXAVffV+U1Fw==
 
-"@stellar/eslint-config@^1.0.4":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@stellar/eslint-config/-/eslint-config-1.0.4.tgz#bd5c23f4d2f7f038909c5910e4c0ca6dbd035ea1"
-  integrity sha512-lxhnBVUBA6/B/cVT6PHMbjXxxtapcpmItIhvBOvqyd4jJlXvDDk575wO7SADOk2PEc/DE+ozjsQzOx3uvU8taA==
+"@stellar/eslint-config@^1.0.5":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@stellar/eslint-config/-/eslint-config-1.0.5.tgz#00616eb6342e839ffa5c0d9e2539dccd64ede764"
+  integrity sha512-RpkhdJffBU1oEsdyAJgfKHDSRJCWbyNOp08F1UP0yGp1tBLp0FopURl7m1Nx2Xd1o1PkN6h01wV6lpdiCbZWYQ==
 
 "@stellar/lyra-api@^1.0.0-alpha.2":
   version "1.0.0-alpha.2"
@@ -1550,11 +1555,12 @@
   resolved "https://registry.yarnpkg.com/@stellar/tsconfig/-/tsconfig-1.0.2.tgz#18e9b1a1d6076e116bb405d11fc034401155292d"
   integrity sha512-lC51QSlYRM8K3oGe0/WGPq+p9+u+yPzwZXSKrZXKOe4sq79vzfiqFbQyp5enOffFzXlahcDyTgY67mBOkJytfw==
 
-"@stellar/wallet-sdk@^0.1.0-rc.10":
-  version "0.1.0-rc.10"
-  resolved "https://registry.yarnpkg.com/@stellar/wallet-sdk/-/wallet-sdk-0.1.0-rc.10.tgz#3389c0749deb10991f3537b13c4b67fcad8ca958"
-  integrity sha512-a7hCtTrT+t4Z4ngETjrNdL1mykiFdGPHIzQSlhjQ4wF2nUVAQeskLPY5KOox9AHekbPiclu+UbAo/Okrk+ATjw==
+"@stellar/wallet-sdk@^0.1.0-rc.11":
+  version "0.1.0-rc.11"
+  resolved "https://registry.yarnpkg.com/@stellar/wallet-sdk/-/wallet-sdk-0.1.0-rc.11.tgz#115870869c85e0481c517bc4b973d943a8f7f673"
+  integrity sha512-8WaYN4nJMoiF2A1m5LPmi65MwLCii61IUj6IZjmfKsZAlDTxee+MyrL9CeqKiJ/lFdV4+E+m2M/5cwaH48UmlA==
   dependencies:
+    "@albedo-link/intent" "^0.9.2"
     "@ledgerhq/hw-app-str" "^4.48.0"
     "@ledgerhq/hw-transport-u2f" "^4.48.0"
     "@stellar/lyra-api" "^1.0.0-alpha.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@albedo-link/intent@^0.9.0":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@albedo-link/intent/-/intent-0.9.0.tgz#cc5b6e2822b4f1b2c78be334e9fe82f9facf11f7"
+  integrity sha512-NYxJCJebB7oFtycS/GID0z+/IIYE+OGAzk14nqUy8N9FegcjKyFngQisRswXM8FZLrLmHO5lv643Qx3YE4PX0g==
+
 "@babel/code-frame@7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.8.3.tgz#33e25903d7481181534e12ec0a25f16b6fcf419e"


### PR DESCRIPTION
- Sign in and sign transactions with Albedo wallet.
- Reset store for Ledger modal on unmount to keep the store clean and up to date.
- Upgrade `wallet-sdk` and `eslint-config` packages.