### PR TITLE
Reset wallet state when modal is closed

### DIFF
--- a/src/components/SignIn/SignInAlbedoForm.tsx
+++ b/src/components/SignIn/SignInAlbedoForm.tsx
@@ -12,10 +12,7 @@ import { ErrorMessage } from "components/ErrorMessage";
 import { fetchAccountAction, resetAccountAction } from "ducks/account";
 import { storeKeyAction } from "ducks/keyStore";
 import { updateSettingsAction } from "ducks/settings";
-import {
-  fetchAlbedoStellarAddressAction,
-  resetAlbedoAction,
-} from "ducks/wallet/albedo";
+import { fetchAlbedoStellarAddressAction } from "ducks/wallet/albedo";
 import { useErrorMessage } from "hooks/useErrorMessage";
 import { useRedux } from "hooks/useRedux";
 import { ActionStatus, AuthType, ModalPageProps } from "types/types.d";
@@ -39,7 +36,8 @@ export const SignInAlbedoForm = ({ onClose }: ModalPageProps) => {
   const { errorMessage, setErrorMessage } = useErrorMessage({
     initialMessage: albedoErrorMessage || accountErrorMessage,
     onUnmount: () => {
-      dispatch(resetAlbedoAction());
+      // Reset account store, if there are errors.
+      // walletAlbedo store is reset every time modal is closed.
       dispatch(resetAccountAction());
     },
   });

--- a/src/components/SignIn/SignInLedgerForm.tsx
+++ b/src/components/SignIn/SignInLedgerForm.tsx
@@ -16,10 +16,7 @@ import { defaultStellarBipPath } from "constants/settings";
 import { fetchAccountAction, resetAccountAction } from "ducks/account";
 import { storeKeyAction } from "ducks/keyStore";
 import { updateSettingsAction } from "ducks/settings";
-import {
-  fetchLedgerStellarAddressAction,
-  resetLedgerAction,
-} from "ducks/wallet/ledger";
+import { fetchLedgerStellarAddressAction } from "ducks/wallet/ledger";
 import { useErrorMessage } from "hooks/useErrorMessage";
 import { useRedux } from "hooks/useRedux";
 import { ActionStatus, AuthType, ModalPageProps } from "types/types.d";
@@ -56,7 +53,8 @@ export const SignInLedgerForm = ({ onClose }: ModalPageProps) => {
   const { errorMessage, setErrorMessage } = useErrorMessage({
     initialMessage: ledgerErrorMessage || accountErrorMessage,
     onUnmount: () => {
-      dispatch(resetLedgerAction());
+      // Reset account store, if there are errors.
+      // walletLedger store is reset every time modal is closed.
       dispatch(resetAccountAction());
     },
   });

--- a/src/components/SignIn/SignInLyraForm.tsx
+++ b/src/components/SignIn/SignInLyraForm.tsx
@@ -14,10 +14,7 @@ import { ErrorMessage } from "components/ErrorMessage";
 import { fetchAccountAction, resetAccountAction } from "ducks/account";
 import { storeKeyAction } from "ducks/keyStore";
 import { updateSettingsAction } from "ducks/settings";
-import {
-  fetchLyraStellarAddressAction,
-  resetLyraAction,
-} from "ducks/wallet/lyra";
+import { fetchLyraStellarAddressAction } from "ducks/wallet/lyra";
 import { useErrorMessage } from "hooks/useErrorMessage";
 import { useRedux } from "hooks/useRedux";
 import { ActionStatus, AuthType, ModalPageProps } from "types/types.d";
@@ -41,7 +38,8 @@ export const SignInLyraForm = ({ onClose }: ModalPageProps) => {
   const { errorMessage, setErrorMessage } = useErrorMessage({
     initialMessage: lyraErrorMessage || accountErrorMessage,
     onUnmount: () => {
-      dispatch(resetLyraAction());
+      // Reset account store, if there are errors.
+      // walletLyra store is reset every time modal is closed.
       dispatch(resetAccountAction());
     },
   });

--- a/src/components/SignIn/SignInTrezorForm.tsx
+++ b/src/components/SignIn/SignInTrezorForm.tsx
@@ -13,10 +13,7 @@ import { ModalWalletContent } from "components/ModalWalletContent";
 import { fetchAccountAction, resetAccountAction } from "ducks/account";
 import { storeKeyAction } from "ducks/keyStore";
 import { updateSettingsAction } from "ducks/settings";
-import {
-  fetchTrezorStellarAddressAction,
-  resetTrezorAction,
-} from "ducks/wallet/trezor";
+import { fetchTrezorStellarAddressAction } from "ducks/wallet/trezor";
 import { useErrorMessage } from "hooks/useErrorMessage";
 import { useRedux } from "hooks/useRedux";
 import { ActionStatus, AuthType, ModalPageProps } from "types/types.d";
@@ -40,7 +37,8 @@ export const SignInTrezorForm = ({ onClose }: ModalPageProps) => {
   const { errorMessage, setErrorMessage } = useErrorMessage({
     initialMessage: trezorErrorMessage || accountErrorMessage,
     onUnmount: () => {
-      dispatch(resetTrezorAction());
+      // Reset account store, if there are errors.
+      // walletTrezor store is reset every time modal is closed.
       dispatch(resetAccountAction());
     },
   });

--- a/src/ducks/wallet/albedo.ts
+++ b/src/ducks/wallet/albedo.ts
@@ -53,9 +53,12 @@ const walletAlbedoSlice = createSlice({
     builder.addCase(
       fetchAlbedoStellarAddressAction.rejected,
       (state, action) => {
-        state.data = null;
-        state.status = ActionStatus.ERROR;
-        state.errorString = action.payload?.errorString;
+        // Do not update state if user has closed modal and left Albedo open
+        if (state.status) {
+          state.data = null;
+          state.status = ActionStatus.ERROR;
+          state.errorString = action.payload?.errorString;
+        }
       },
     );
   },

--- a/src/ducks/wallet/ledger.ts
+++ b/src/ducks/wallet/ledger.ts
@@ -53,9 +53,12 @@ const walletLedgerSlice = createSlice({
     builder.addCase(
       fetchLedgerStellarAddressAction.rejected,
       (state, action) => {
-        state.data = null;
-        state.status = ActionStatus.ERROR;
-        state.errorString = action.payload?.errorString;
+        // Do not update state if user has closed modal and left Ledger tab open
+        if (state.status) {
+          state.data = null;
+          state.status = ActionStatus.ERROR;
+          state.errorString = action.payload?.errorString;
+        }
       },
     );
   },

--- a/src/ducks/wallet/lyra.ts
+++ b/src/ducks/wallet/lyra.ts
@@ -57,9 +57,12 @@ const walletLyraSlice = createSlice({
     );
 
     builder.addCase(fetchLyraStellarAddressAction.rejected, (state, action) => {
-      state.data = null;
-      state.status = ActionStatus.ERROR;
-      state.errorString = action.payload?.errorString;
+      // Do not update state if user has closed modal and left Lyra open
+      if (state.status) {
+        state.data = null;
+        state.status = ActionStatus.ERROR;
+        state.errorString = action.payload?.errorString;
+      }
     });
   },
 });

--- a/src/ducks/wallet/trezor.ts
+++ b/src/ducks/wallet/trezor.ts
@@ -66,9 +66,12 @@ const walletTrezorSlice = createSlice({
     builder.addCase(
       fetchTrezorStellarAddressAction.rejected,
       (state, action) => {
-        state.data = null;
-        state.status = ActionStatus.ERROR;
-        state.errorString = action.payload?.errorString;
+        // Do not update state if user has closed modal and left Trezor tab open
+        if (state.status) {
+          state.data = null;
+          state.status = ActionStatus.ERROR;
+          state.errorString = action.payload?.errorString;
+        }
       },
     );
   },

--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import styled from "styled-components";
+import { useDispatch } from "react-redux";
 
 // TODO: update Lyra logo once we have it.
 import logoLyra from "assets/images/logo-lyra.png";
@@ -21,6 +22,11 @@ import { SignInTrezorForm } from "components/SignIn/SignInTrezorForm";
 import { WalletButton } from "components/WalletButton";
 
 import { pageInsetStyle } from "constants/styles";
+import { resetAlbedoAction } from "ducks/wallet/albedo";
+import { resetLedgerAction } from "ducks/wallet/ledger";
+import { resetLyraAction } from "ducks/wallet/lyra";
+import { resetTrezorAction } from "ducks/wallet/trezor";
+import { ModalType } from "types/types.d";
 
 const WrapperEl = styled.div`
   ${pageInsetStyle};
@@ -60,17 +66,28 @@ const ButtonsWrapperEl = styled.div`
   }
 `;
 
-enum ModalType {
-  SIGNIN_SECRET_KEY,
-  SIGNIN_TREZOR,
-  SIGNIN_LEDGER,
-  SIGNIN_LYRA,
-  SIGNIN_ALBEDO,
-  NEW_KEY_PAIR,
-}
-
 export const Landing = () => {
+  const dispatch = useDispatch();
   const [activeModal, setActiveModal] = useState<ModalType | null>(null);
+
+  const resetWalletState = (type: ModalType | null) => {
+    switch (type) {
+      case ModalType.SIGNIN_TREZOR:
+        dispatch(resetTrezorAction());
+        break;
+      case ModalType.SIGNIN_LEDGER:
+        dispatch(resetLedgerAction());
+        break;
+      case ModalType.SIGNIN_LYRA:
+        dispatch(resetLyraAction());
+        break;
+      case ModalType.SIGNIN_ALBEDO:
+        dispatch(resetAlbedoAction());
+        break;
+      default:
+      // Do nothing
+    }
+  };
 
   const openModal = (type: ModalType) => {
     setActiveModal(type);
@@ -78,9 +95,10 @@ export const Landing = () => {
 
   const closeModal = () => {
     setActiveModal(null);
+    resetWalletState(activeModal);
   };
 
-  const renderModal = () => {
+  const renderModalContent = () => {
     switch (activeModal) {
       case ModalType.SIGNIN_SECRET_KEY:
         return <SignInSecretKeyForm onClose={closeModal} />;
@@ -161,7 +179,7 @@ export const Landing = () => {
       </ButtonsWrapperEl>
 
       <Modal visible={activeModal !== null} onClose={closeModal}>
-        {renderModal()}
+        {renderModalContent()}
       </Modal>
     </WrapperEl>
   );

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -44,3 +44,12 @@ export interface ThemeProps {
 export interface Theme {
   [themeName: string]: ThemeProps;
 }
+
+export enum ModalType {
+  SIGNIN_SECRET_KEY = "SIGNIN_SECRET_KEY",
+  SIGNIN_TREZOR = "SIGNIN_TREZOR",
+  SIGNIN_LEDGER = "SIGNIN_LEDGER",
+  SIGNIN_LYRA = "SIGNIN_LYRA",
+  SIGNIN_ALBEDO = "SIGNIN_ALBEDO",
+  NEW_KEY_PAIR = "NEW_KEY_PAIR",
+}


### PR DESCRIPTION
The issue was that, if a user started the sign-in process with a wallet (Trezor, for example), a new browser tab would be opened. If the user closed the modal but left the tab open, the wallet state wasn't reset. When the wallet tab was closed, it would trigger the error state, and user would see an error message when opened the modal next.

This update resets a wallet state any time the wallet modal is closed. Closing the tab later will only trigger reject action from the initial call, but it will not update UI.