### PR TITLE
Preserve URL query params when changing routes

### DIFF
--- a/src/components/SignIn/SignInAlbedoForm.tsx
+++ b/src/components/SignIn/SignInAlbedoForm.tsx
@@ -66,7 +66,10 @@ export const SignInAlbedoForm = ({ onClose }: ModalPageProps) => {
   useEffect(() => {
     if (accountStatus === ActionStatus.SUCCESS) {
       if (isAuthenticated) {
-        history.push("/dashboard");
+        history.push({
+          pathname: "/dashboard",
+          search: history.location.search,
+        });
         dispatch(updateSettingsAction({ authType: AuthType.ALBEDO }));
       } else {
         setErrorMessage("Something went wrong, please try again.");

--- a/src/components/SignIn/SignInLedgerForm.tsx
+++ b/src/components/SignIn/SignInLedgerForm.tsx
@@ -76,7 +76,10 @@ export const SignInLedgerForm = ({ onClose }: ModalPageProps) => {
 
   useEffect(() => {
     if (isAuthenticated) {
-      history.push("/dashboard");
+      history.push({
+        pathname: "/dashboard",
+        search: history.location.search,
+      });
       dispatch(updateSettingsAction({ authType: AuthType.LEDGER }));
       dispatch(
         storeKeyAction({

--- a/src/components/SignIn/SignInLyraForm.tsx
+++ b/src/components/SignIn/SignInLyraForm.tsx
@@ -79,7 +79,10 @@ export const SignInLyraForm = ({ onClose }: ModalPageProps) => {
   useEffect(() => {
     if (accountStatus === ActionStatus.SUCCESS) {
       if (isAuthenticated) {
-        history.push("/dashboard");
+        history.push({
+          pathname: "/dashboard",
+          search: history.location.search,
+        });
         dispatch(updateSettingsAction({ authType: AuthType.LYRA }));
       } else {
         setErrorMessage("Something went wrong, please try again.");

--- a/src/components/SignIn/SignInSecretKeyForm.tsx
+++ b/src/components/SignIn/SignInSecretKeyForm.tsx
@@ -53,7 +53,10 @@ export const SignInSecretKeyForm = ({ onClose }: ModalPageProps) => {
   useEffect(() => {
     if (status === ActionStatus.SUCCESS) {
       if (isAuthenticated) {
-        history.push("/dashboard");
+        history.push({
+          pathname: "/dashboard",
+          search: history.location.search,
+        });
         dispatch(updateSettingsAction({ authType: AuthType.PRIVATE_KEY }));
         dispatch(
           storeKeyAction({

--- a/src/components/SignIn/SignInTrezorForm.tsx
+++ b/src/components/SignIn/SignInTrezorForm.tsx
@@ -76,7 +76,10 @@ export const SignInTrezorForm = ({ onClose }: ModalPageProps) => {
   useEffect(() => {
     if (accountStatus === ActionStatus.SUCCESS) {
       if (isAuthenticated) {
-        history.push("/dashboard");
+        history.push({
+          pathname: "/dashboard",
+          search: history.location.search,
+        });
         dispatch(updateSettingsAction({ authType: AuthType.TREZOR }));
       } else {
         setErrorMessage("Something went wrong, please try again.");


### PR DESCRIPTION
The network banner message was wrong because we were losing query param `testnet=true` when navigating to Dashboard.