### PR TITLE
Use env vars from backend generated file

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -18,34 +18,13 @@
       property="og:image"
       content="https://accountviewer.stellar.org/images/og-image.jpg"
     />
-    <!--
-      manifest.json provides metadata used when your web app is installed on a
-      user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
-    -->
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <!--
-      Notice the use of %PUBLIC_URL% in the tags above.
-      It will be replaced with the URL of the `public` folder during the build.
-      Only files inside the `public` folder can be referenced from the HTML.
 
-      Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
-      work correctly both with client-side routing and a non-root public URL.
-      Learn how to configure a non-root public URL by running `npm run build`.
-    -->
+    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <title>Account Viewer - Stellar</title>
+    <script src="%PUBLIC_URL%/settings/env-config.js"></script>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
-    <!--
-      This HTML file is a template.
-      If you open it directly in the browser, you will see an empty page.
-
-      You can add webfonts, meta tags, or analytics to this file.
-      The build step will place the bundled scripts into the <body> tag.
-
-      To begin the development, run `npm start` or `yarn start`.
-      To create a production bundle, use `npm run build` or `yarn build`.
-    -->
   </body>
 </html>

--- a/public/settings/env-config.js
+++ b/public/settings/env-config.js
@@ -1,0 +1,3 @@
+window._env_ = {
+  AMPLITUDE_API_KEY: "",
+};

--- a/src/helpers/tracking.ts
+++ b/src/helpers/tracking.ts
@@ -1,7 +1,7 @@
 import Amplitude from "amplitude-js";
 
 const instance = Amplitude.getInstance();
-instance.init(process.env.REACT_APP_AMPLITUDE_API_KEY || "", undefined, {
+instance.init(window._env_.AMPLITUDE_API_KEY, undefined, {
   trackingOptions: {
     ip_address: false,
   },

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -1,3 +1,11 @@
+declare global {
+  interface Window {
+    _env_: {
+      AMPLITUDE_API_KEY: string;
+    };
+  }
+}
+
 export enum NetworkType {
   TESTNET = "testnet",
   PUBLIC = "public",


### PR DESCRIPTION
- `settings/env-config.js` is a placeholder, real content will be generated on the server.
- Removed unnecessary comments in `index.html`.