### PR TITLE
Payments history: hide min amounts for all payments

### DIFF
--- a/src/components/TransactionHistory.tsx
+++ b/src/components/TransactionHistory.tsx
@@ -303,10 +303,6 @@ export const TransactionHistory = () => {
         return true;
       }
 
-      if (tx.isRecipient) {
-        return true;
-      }
-
       return new BigNumber(tx.amount).gt(TX_HISTORY_MIN_AMOUNT);
     });
 


### PR DESCRIPTION
This was a bug, we want to have the same show/hide logic for incoming and outgoing payments in history.