### PR TITLE
Refactor CreateTransaction component state

### DIFF
--- a/src/components/SendTransaction/SendTransactionFlow.tsx
+++ b/src/components/SendTransaction/SendTransactionFlow.tsx
@@ -24,7 +24,6 @@ const initialFormData: PaymentFormData = {
   amount: "",
   memoType: MemoNone,
   memoContent: "",
-  memoRequiredMessage: "",
   isAccountFunded: true,
 };
 

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -140,6 +140,5 @@ export interface PaymentFormData {
   amount: string;
   memoType: MemoType;
   memoContent: MemoValue;
-  memoRequiredMessage?: string;
   isAccountFunded: boolean;
 }


### PR DESCRIPTION
Refactored `CreateTransaction` state from object to individual state form inputs. The problem was that spreading the whole object when updating value would sometimes overwrite new values with old ones. That issue is no longer a problem when values are updated individually.